### PR TITLE
Feat/treatment schedule

### DIFF
--- a/src/main/java/emp/emp/calendar/controller/CalendarController.java
+++ b/src/main/java/emp/emp/calendar/controller/CalendarController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/calendar")
+@RequestMapping("/api/auth/user/calendar")
 @RequiredArgsConstructor
 public class CalendarController {
 

--- a/src/main/java/emp/emp/calendar/controller/CalendarController.java
+++ b/src/main/java/emp/emp/calendar/controller/CalendarController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -71,4 +72,29 @@ public class CalendarController {
   ) {
     return calendarService.getAllEvents(userDetails);
   }
+
+  /**
+   * 특정 날짜 일정 조회
+   */
+  @GetMapping("/date")
+  public List<CalendarEventResponse> getEventsByDate(
+          @AuthenticationPrincipal CustomUserDetails userDetails,
+          @RequestParam LocalDateTime date
+  ) {
+    return calendarService.getEventsByDate(userDetails, date);
+  }
+
+  /**
+   * 캘린더 일정 우선순위 업데이트
+   */
+  @PutMapping("/{eventId}/priority")
+  public CalendarEventResponse updatePriority(
+          @AuthenticationPrincipal CustomUserDetails userDetails,
+          @PathVariable Long eventId,
+          @RequestBody Integer priority
+  ) {
+    return calendarService.updatePriority(userDetails, eventId, priority);
+  }
+
+
 }

--- a/src/main/java/emp/emp/calendar/controller/CalendarController.java
+++ b/src/main/java/emp/emp/calendar/controller/CalendarController.java
@@ -1,0 +1,74 @@
+package emp.emp.calendar.controller;
+
+import emp.emp.auth.custom.CustomUserDetails;
+import emp.emp.calendar.dto.request.CalendarEventRequest;
+import emp.emp.calendar.dto.response.CalendarEventResponse;
+import emp.emp.calendar.service.CalendarService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/calendar")
+@RequiredArgsConstructor
+public class CalendarController {
+
+  private final CalendarService calendarService;
+
+  /**
+   * 캘린더 일정 등록
+   */
+  @PostMapping
+  public CalendarEventResponse createEvent(
+          @AuthenticationPrincipal CustomUserDetails userDetails,
+          @RequestBody CalendarEventRequest request
+  ) {
+    return calendarService.createEvent(userDetails, request);
+  }
+
+  /**
+   * 캘린더 일정 수정
+   */
+  @PutMapping("/{eventId}")
+  public CalendarEventResponse updateEvent(
+          @AuthenticationPrincipal CustomUserDetails userDetails,
+          @PathVariable Long eventId,
+          @RequestBody CalendarEventRequest request
+  ) {
+    return calendarService.updateEvent(userDetails, eventId, request);
+  }
+
+  /**
+   * 캘린더 일정 삭제
+   */
+  @DeleteMapping("/{eventId}")
+  public void deleteEvent(
+          @AuthenticationPrincipal CustomUserDetails userDetails,
+          @PathVariable Long eventId
+  ) {
+    calendarService.deleteEvent(userDetails, eventId);
+  }
+
+  /**
+   * 캘린더 일정 하나하나 조회
+   */
+  @GetMapping("/{eventId}")
+  public CalendarEventResponse getEvent(
+          @AuthenticationPrincipal CustomUserDetails userDetails,
+          @PathVariable Long eventId
+  ) {
+    return calendarService.getEvent(userDetails, eventId);
+  }
+
+  /**
+   * 캘린더 일정 전체 조회
+   */
+  @GetMapping
+  public List<CalendarEventResponse> getAllEvents(
+          @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    return calendarService.getAllEvents(userDetails);
+  }
+}

--- a/src/main/java/emp/emp/calendar/dto/request/CalendarEventRequest.java
+++ b/src/main/java/emp/emp/calendar/dto/request/CalendarEventRequest.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Setter
 public class CalendarEventRequest {
 
-  private Long memberId;
+  private String verifyId;
 
   private CalendarEventType eventType;
 

--- a/src/main/java/emp/emp/calendar/dto/request/CalendarEventRequest.java
+++ b/src/main/java/emp/emp/calendar/dto/request/CalendarEventRequest.java
@@ -1,0 +1,26 @@
+package emp.emp.calendar.dto.request;
+
+import emp.emp.calendar.enums.CalendarEventType;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 캘린더 이벤트 등록, 수정용 DTO
+ */
+@Getter
+@Setter
+public class CalendarEventRequest {
+
+  private Long memberId;
+
+  private CalendarEventType eventType;
+
+  private String title;
+
+  private LocalDateTime startDate;
+
+  private LocalDateTime endDate;
+
+}

--- a/src/main/java/emp/emp/calendar/dto/request/CalendarEventRequest.java
+++ b/src/main/java/emp/emp/calendar/dto/request/CalendarEventRequest.java
@@ -23,4 +23,6 @@ public class CalendarEventRequest {
 
   private LocalDateTime endDate;
 
+  private Integer priority;
+
 }

--- a/src/main/java/emp/emp/calendar/dto/response/CalendarEventResponse.java
+++ b/src/main/java/emp/emp/calendar/dto/response/CalendarEventResponse.java
@@ -18,5 +18,6 @@ public class CalendarEventResponse {
   private String title;
   private LocalDateTime startDate;
   private LocalDateTime endDate;
+  private Integer priority;
 
 }

--- a/src/main/java/emp/emp/calendar/dto/response/CalendarEventResponse.java
+++ b/src/main/java/emp/emp/calendar/dto/response/CalendarEventResponse.java
@@ -1,0 +1,22 @@
+package emp.emp.calendar.dto.response;
+
+import emp.emp.calendar.enums.CalendarEventType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 캘린더 이벤트 조회용 DTO
+ */
+@Getter
+@Builder
+public class CalendarEventResponse {
+  private Long eventId;
+  private Long memberId;
+  private CalendarEventType eventType;
+  private String title;
+  private LocalDateTime startDate;
+  private LocalDateTime endDate;
+
+}

--- a/src/main/java/emp/emp/calendar/dto/response/CalendarEventResponse.java
+++ b/src/main/java/emp/emp/calendar/dto/response/CalendarEventResponse.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Builder
 public class CalendarEventResponse {
   private Long eventId;
-  private Long memberId;
+  private String verifyId;
   private CalendarEventType eventType;
   private String title;
   private LocalDateTime startDate;

--- a/src/main/java/emp/emp/calendar/entity/CalendarEvent.java
+++ b/src/main/java/emp/emp/calendar/entity/CalendarEvent.java
@@ -1,0 +1,46 @@
+package emp.emp.calendar.entity;
+
+import emp.emp.calendar.dto.request.CalendarEventRequest;
+import emp.emp.calendar.enums.CalendarEventType;
+import emp.emp.member.entity.Member;
+import emp.emp.util.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CalendarEvent extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "event_id")
+  private Long eventId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  @Enumerated(EnumType.STRING)
+  private CalendarEventType eventType;
+
+  private String title;
+
+  private LocalDateTime startDate;
+
+  private LocalDateTime endDate;
+
+  public void update(CalendarEventRequest request) {
+    this.eventType = request.getEventType(); // enum 타입으로 매핑됨
+    this.title = request.getTitle();
+    this.startDate = request.getStartDate();
+    this.endDate = request.getEndDate();
+  }
+}

--- a/src/main/java/emp/emp/calendar/entity/CalendarEvent.java
+++ b/src/main/java/emp/emp/calendar/entity/CalendarEvent.java
@@ -5,15 +5,13 @@ import emp.emp.calendar.enums.CalendarEventType;
 import emp.emp.member.entity.Member;
 import emp.emp.util.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -37,10 +35,13 @@ public class CalendarEvent extends BaseEntity {
 
   private LocalDateTime endDate;
 
+  private Integer priority;
+
   public void update(CalendarEventRequest request) {
     this.eventType = request.getEventType(); // enum 타입으로 매핑됨
     this.title = request.getTitle();
     this.startDate = request.getStartDate();
     this.endDate = request.getEndDate();
+    this.priority = request.getPriority();
   }
 }

--- a/src/main/java/emp/emp/calendar/enums/CalendarEventType.java
+++ b/src/main/java/emp/emp/calendar/enums/CalendarEventType.java
@@ -1,0 +1,7 @@
+package emp.emp.calendar.enums;
+
+public enum CalendarEventType {
+  RESERVATION, // 진료예약
+  CHECKUP, // 진료 결과
+  MEDICATION; // 복약관리
+}

--- a/src/main/java/emp/emp/calendar/repository/CalendarRepository.java
+++ b/src/main/java/emp/emp/calendar/repository/CalendarRepository.java
@@ -1,0 +1,41 @@
+package emp.emp.calendar.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import emp.emp.calendar.entity.CalendarEvent;
+import emp.emp.member.entity.Member;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface CalendarRepository extends JpaRepository<CalendarEvent, Long> {
+
+  /**
+   * 특정 멤버의 모든 일정을 찾는 메서드
+   * @param member
+   */
+  List<CalendarEvent> findByMember(Member member);
+
+  /**
+   * 특정 기간 내의 일정을 찾는 메서드
+   * @param start
+   * @param end
+   */
+  List<CalendarEvent> findByStartDateBetween(LocalDateTime start, LocalDateTime end);
+
+  /**
+   * 특정 이벤트 타입의 일정을 찾는 메서드
+   * @param eventType
+   */
+  List<CalendarEvent> findByEventType(String eventType);
+
+  /**
+   * 특정 멤버와 기간으로 일정을 찾는 메서드
+   * @param member
+   * @param start
+   * @param end
+   */
+  List<CalendarEvent> findByMemberAndStartDateBetween(Member member, LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/emp/emp/calendar/repository/CalendarRepository.java
+++ b/src/main/java/emp/emp/calendar/repository/CalendarRepository.java
@@ -38,4 +38,23 @@ public interface CalendarRepository extends JpaRepository<CalendarEvent, Long> {
    * @param end
    */
   List<CalendarEvent> findByMemberAndStartDateBetween(Member member, LocalDateTime start, LocalDateTime end);
+
+  /**
+   * 특정 날짜의 일정을 찾는 메서드
+   * @param start
+   * @param end
+   * @return
+   */
+  List<CalendarEvent> findByStartDateBetweenOrderByPriorityAsc(
+          LocalDateTime start, LocalDateTime end);
+
+  /**
+   * 특정 멤버의 특정 날짜 일정을 우선순위대로 정렬하여 찾는 메서드
+   * @param member
+   * @param start
+   * @param end
+   * @return
+   */
+  List<CalendarEvent> findByMemberAndStartDateBetweenOrderByPriorityAsc(
+          Member member, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/emp/emp/calendar/service/CalendarService.java
+++ b/src/main/java/emp/emp/calendar/service/CalendarService.java
@@ -4,6 +4,7 @@ import emp.emp.auth.custom.CustomUserDetails;
 import emp.emp.calendar.dto.request.CalendarEventRequest;
 import emp.emp.calendar.dto.response.CalendarEventResponse;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CalendarService {
@@ -22,4 +23,10 @@ public interface CalendarService {
 
   // 회원의 전체 일정 조회
   List<CalendarEventResponse> getAllEvents(CustomUserDetails userDetails);
+
+  // 특정 날짜 일정 조회
+  List<CalendarEventResponse> getEventsByDate(CustomUserDetails userDetails, LocalDateTime date);
+
+  // 우선순위 업데이트
+  CalendarEventResponse updatePriority(CustomUserDetails userDetails, Long eventId, Integer priority);
 }

--- a/src/main/java/emp/emp/calendar/service/CalendarService.java
+++ b/src/main/java/emp/emp/calendar/service/CalendarService.java
@@ -1,0 +1,25 @@
+package emp.emp.calendar.service;
+
+import emp.emp.auth.custom.CustomUserDetails;
+import emp.emp.calendar.dto.request.CalendarEventRequest;
+import emp.emp.calendar.dto.response.CalendarEventResponse;
+
+import java.util.List;
+
+public interface CalendarService {
+
+  // 일정 등록
+  CalendarEventResponse createEvent(CustomUserDetails userDetails, CalendarEventRequest request);
+
+  // 일정 수정
+  CalendarEventResponse updateEvent(CustomUserDetails userDetails, Long eventId, CalendarEventRequest request);
+
+  // 일정 삭제
+  void deleteEvent(CustomUserDetails userDetails, Long eventId);
+
+  // 특정 이벤트 조회
+  CalendarEventResponse getEvent(CustomUserDetails userDetails, Long eventId);
+
+  // 회원의 전체 일정 조회
+  List<CalendarEventResponse> getAllEvents(CustomUserDetails userDetails);
+}

--- a/src/main/java/emp/emp/calendar/service/CalendarServiceImpl.java
+++ b/src/main/java/emp/emp/calendar/service/CalendarServiceImpl.java
@@ -122,7 +122,8 @@ public class CalendarServiceImpl implements CalendarService {
   private CalendarEventResponse toResponse(CalendarEvent calendarEvent) {
     return CalendarEventResponse.builder()
             .eventId(calendarEvent.getEventId())
-            .memberId(calendarEvent.getMember().getId())
+            // .verifyId(calendarEvent.getMember().getId())
+            .verifyId(calendarEvent.getMember().getVerifyId())
             .eventType(calendarEvent.getEventType())
             .title(calendarEvent.getTitle())
             .startDate(calendarEvent.getStartDate())

--- a/src/main/java/emp/emp/calendar/service/CalendarServiceImpl.java
+++ b/src/main/java/emp/emp/calendar/service/CalendarServiceImpl.java
@@ -1,0 +1,132 @@
+package emp.emp.calendar.service;
+
+import emp.emp.auth.custom.CustomUserDetails;
+import emp.emp.calendar.dto.request.CalendarEventRequest;
+import emp.emp.calendar.dto.response.CalendarEventResponse;
+import emp.emp.calendar.entity.CalendarEvent;
+import emp.emp.calendar.repository.CalendarRepository;
+import emp.emp.member.entity.Member;
+import emp.emp.member.repository.MemberRepository;
+import emp.emp.util.security.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CalendarServiceImpl implements CalendarService {
+
+  private final CalendarRepository calendarRepository;
+  private final MemberRepository memberRepository;
+  private final SecurityUtil securityUtil;
+
+  /**
+   * [일정 등록]
+   * 현재 로그인한 사용자의 정보로 CalendarEvent를 생성하여 저장
+   */
+  @Override
+  @Transactional
+  public CalendarEventResponse createEvent(CustomUserDetails userDetails, CalendarEventRequest request) {
+    Member currentMember = securityUtil.getCurrentMember();
+
+    CalendarEvent calendarEvent = CalendarEvent.builder()
+            .member(currentMember)
+            .eventType(request.getEventType())
+            .title(request.getTitle())
+            .startDate(request.getStartDate())
+            .endDate(request.getEndDate())
+            .build();
+
+    calendarRepository.save(calendarEvent);
+
+    return toResponse(calendarEvent);
+  }
+
+  /**
+   * [일정 수정]
+   * 이벤트 ID로 기존 일정을 조회하고
+   * 본인 소유인지 검증 후 데이터를 수정
+   */
+  @Override
+  @Transactional
+  public CalendarEventResponse updateEvent(CustomUserDetails userDetails, Long eventId, CalendarEventRequest request) {
+    Member currentMember = securityUtil.getCurrentMember();
+
+    CalendarEvent calendarEvent = findByIdAndValidate(eventId, currentMember);
+
+    calendarEvent.update(request);
+
+    return toResponse(calendarEvent);
+  }
+
+  /**
+   * [일정 삭제]
+   * 이벤트 ID로 조회한 후
+   * 본인 소유 일정이면 삭제
+   */
+  @Override
+  @Transactional
+  public void deleteEvent(CustomUserDetails userDetails, Long eventId) {
+    Member currentMember = securityUtil.getCurrentMember();
+    CalendarEvent calendarEvent = findByIdAndValidate(eventId, currentMember);
+
+    calendarRepository.delete(calendarEvent);
+  }
+
+  /**
+   * [특정 이벤트 조회]
+   * 이벤트 ID로 조회한 후
+   * 본인의 일정이 맞는지 확인하고 반환
+   */
+  @Override
+  public CalendarEventResponse getEvent(CustomUserDetails userDetails, Long eventId) {
+    Member currentMember = securityUtil.getCurrentMember();
+    CalendarEvent calendarEvent = findByIdAndValidate(eventId, currentMember);
+
+    return toResponse(calendarEvent);
+  }
+
+  /**
+   * 로그인한 사용자의 전체 일정 조회
+   */
+  @Override
+  public List<CalendarEventResponse> getAllEvents(CustomUserDetails userDetails) {
+    Member currentMember = securityUtil.getCurrentMember();
+
+    return calendarRepository.findByMember(currentMember).stream()
+            .map(this::toResponse)
+            .collect(Collectors.toList());
+  }
+
+  /**
+   * [일정 ID로 조회 + 현재 사용자의 일정인지 검증]
+   * 본인이 소유한 일정이 아닐 경우 예외 발생
+   */
+  private CalendarEvent findByIdAndValidate(Long eventId, Member currentMember) {
+    CalendarEvent calendarEvent = calendarRepository.findById(eventId)
+            .orElseThrow(() -> new RuntimeException("일정을 찾을 수 없습니다."));
+
+    if (!calendarEvent.getMember().equals(currentMember)) {
+      throw new RuntimeException("접근 권한이 없습니다.");
+    }
+
+    return calendarEvent;
+  }
+
+  /**
+   * CalendarEvent 엔티티를 CalendarEventResponse DTO로 변환
+   */
+  private CalendarEventResponse toResponse(CalendarEvent calendarEvent) {
+    return CalendarEventResponse.builder()
+            .eventId(calendarEvent.getEventId())
+            .memberId(calendarEvent.getMember().getId())
+            .eventType(calendarEvent.getEventType())
+            .title(calendarEvent.getTitle())
+            .startDate(calendarEvent.getStartDate())
+            .endDate(calendarEvent.getEndDate())
+            .build();
+  }
+}

--- a/src/main/java/emp/emp/calendar/util/CalendarUtil.java
+++ b/src/main/java/emp/emp/calendar/util/CalendarUtil.java
@@ -1,0 +1,4 @@
+package emp.emp.calendar.util;
+
+public class CalendarUtil {
+}

--- a/src/main/java/emp/emp/health/exception/HealthErrorCode.java
+++ b/src/main/java/emp/emp/health/exception/HealthErrorCode.java
@@ -8,13 +8,15 @@ import lombok.Getter;
 @Getter
 public enum HealthErrorCode implements ErrorCode {
 
-	TYPE_ERROR(HttpStatus.BAD_REQUEST, "잘못된 건강 타입"),
-	ALREADY_RECORD_TODAY(HttpStatus.BAD_REQUEST, "이미 오늘의 건강 기록을 등록했습니다");
+	TYPE_ERROR("Heal-001", HttpStatus.BAD_REQUEST, "잘못된 건강 타입"),
+	ALREADY_RECORD_TODAY("Heal-001", HttpStatus.BAD_REQUEST, "이미 오늘의 건강 기록을 등록했습니다");
 
+	private final String code;
 	private final HttpStatus httpStatus;
 	private final String message;
 
-	HealthErrorCode(HttpStatus httpStatus, String message) {
+	HealthErrorCode(String code, HttpStatus httpStatus, String message) {
+		this.code = code;
 		this.httpStatus = httpStatus;
 		this.message = message;
 	}

--- a/src/main/java/emp/emp/member/entity/Member.java
+++ b/src/main/java/emp/emp/member/entity/Member.java
@@ -2,20 +2,15 @@ package emp.emp.member.entity;
 
 import java.time.LocalDate;
 import java.time.Period;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
 
+import emp.emp.calendar.entity.CalendarEvent;
 import emp.emp.family.entity.Family;
 import emp.emp.member.enums.Role;
 import emp.emp.util.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -100,4 +95,9 @@ public class Member extends BaseEntity {
 	public void setAddress(String address) {
 		this.address = address;
 	}
+
+	@OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+	private List<CalendarEvent> calendarEvent = new ArrayList<>();
+
+
 }

--- a/src/main/java/emp/emp/treatmentSchedule/controller/TreatmentScheduleController.java
+++ b/src/main/java/emp/emp/treatmentSchedule/controller/TreatmentScheduleController.java
@@ -1,16 +1,19 @@
 package emp.emp.treatmentSchedule.controller;
 
 import emp.emp.auth.custom.CustomUserDetails;
+import emp.emp.exception.BusinessException;
 import emp.emp.treatmentSchedule.dto.request.TreatmentScheduleRequest;
 import emp.emp.treatmentSchedule.dto.response.TreatmentScheduleResponse;
+import emp.emp.treatmentSchedule.exception.TreatmentErrorCode;
 import emp.emp.treatmentSchedule.service.TreatmentScheduleService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+
+@Slf4j
 @RestController
 @RequestMapping("/api/auth/user/treatment")
 @RequiredArgsConstructor
@@ -25,11 +28,70 @@ public class TreatmentScheduleController {
    * @return
    */
   @PostMapping
-  public TreatmentScheduleResponse createTreatmentSchedule(
+  public ResponseEntity<TreatmentScheduleResponse> createTreatmentSchedule(
           @AuthenticationPrincipal CustomUserDetails userDetails,
           @RequestBody TreatmentScheduleRequest request
   ) {
-    return treatmentScheduleService.createTreatmentSchedule(userDetails, request);
+    log.info("진료일정 등록 요청: {}", request);
+
+    if (request.getEventId() == null) {
+      throw new BusinessException(TreatmentErrorCode.CALENDAR_EVENT_NOT_FOUND);
+    }
+
+    if (request.getLocation() == null || request.getLocation().trim().isEmpty()) {
+      throw new BusinessException(TreatmentErrorCode.INVALID_LOCATION);
+    }
+
+    if (request.getTime() == null) {
+      throw new BusinessException(TreatmentErrorCode.INVALID_TIME_FORMAT);
+    }
+
+    TreatmentScheduleResponse response = treatmentScheduleService.createTreatmentSchedule(userDetails, request);
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 진료일정 수정
+   * @param userDetails 인증된 사용자 정보
+   * @param treatmentId 진료일정 ID
+   * @param request 진료일정 수정 요청 DTO
+   * @return 수정된 진료일정 응답 DTO
+   */
+  @PutMapping("/{treatmentId}")
+  public ResponseEntity<TreatmentScheduleResponse> updateTreatmentSchedule(
+          @AuthenticationPrincipal CustomUserDetails userDetails,
+          @PathVariable Long treatmentId,
+          @RequestBody TreatmentScheduleRequest request
+  ) {
+    log.info("진료일정 수정 요청 - ID: {}, 요청: {}", treatmentId, request);
+
+    if (treatmentId == null) {
+      throw new BusinessException(TreatmentErrorCode.TREATMENT_NOT_FOUND);
+    }
+
+    TreatmentScheduleResponse response = treatmentScheduleService.updateTreatmentSchedule(userDetails, treatmentId, request);
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 진료일정 삭제
+   * @param userDetails 인증된 사용자 정보
+   * @param treatmentId 진료일정 ID
+   * @return 성공 응답
+   */
+  @DeleteMapping("/{treatmentId}")
+  public ResponseEntity<Void> deleteTreatmentSchedule(
+          @AuthenticationPrincipal CustomUserDetails userDetails,
+          @PathVariable Long treatmentId
+  ) {
+    log.info("진료일정 삭제 요청 - ID: {}", treatmentId);
+
+    if (treatmentId == null) {
+      throw new BusinessException(TreatmentErrorCode.TREATMENT_NOT_FOUND);
+    }
+
+    treatmentScheduleService.deleteTreatmentSchedule(userDetails, treatmentId);
+    return ResponseEntity.ok().build();
   }
 
 }

--- a/src/main/java/emp/emp/treatmentSchedule/controller/TreatmentScheduleController.java
+++ b/src/main/java/emp/emp/treatmentSchedule/controller/TreatmentScheduleController.java
@@ -1,0 +1,35 @@
+package emp.emp.treatmentSchedule.controller;
+
+import emp.emp.auth.custom.CustomUserDetails;
+import emp.emp.treatmentSchedule.dto.request.TreatmentScheduleRequest;
+import emp.emp.treatmentSchedule.dto.response.TreatmentScheduleResponse;
+import emp.emp.treatmentSchedule.service.TreatmentScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth/user/treatment")
+@RequiredArgsConstructor
+public class TreatmentScheduleController {
+
+  private final TreatmentScheduleService treatmentScheduleService;
+
+  /**
+   * 진료일정 등록
+   * @param userDetails 사용자 정보
+   * @param request
+   * @return
+   */
+  @PostMapping
+  public TreatmentScheduleResponse createTreatmentSchedule(
+          @AuthenticationPrincipal CustomUserDetails userDetails,
+          @RequestBody TreatmentScheduleRequest request
+  ) {
+    return treatmentScheduleService.createTreatmentSchedule(userDetails, request);
+  }
+
+}

--- a/src/main/java/emp/emp/treatmentSchedule/dto/request/TreatmentScheduleRequest.java
+++ b/src/main/java/emp/emp/treatmentSchedule/dto/request/TreatmentScheduleRequest.java
@@ -1,0 +1,21 @@
+package emp.emp.treatmentSchedule.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 진료일정 등록 DTO
+ */
+@Getter
+@Setter
+public class TreatmentScheduleRequest {
+
+  private Long eventId;
+  private String location;
+  private LocalDateTime time;
+  private String memo;
+  private Boolean isPublic;
+
+}

--- a/src/main/java/emp/emp/treatmentSchedule/dto/response/TreatmentScheduleResponse.java
+++ b/src/main/java/emp/emp/treatmentSchedule/dto/response/TreatmentScheduleResponse.java
@@ -1,0 +1,25 @@
+package emp.emp.treatmentSchedule.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 진료일정 조회용DTO
+ */
+@Getter
+@Builder
+public class TreatmentScheduleResponse {
+
+  private Long treatmentId;
+  private Long eventId;
+  private String verifyId; // 회원식별자
+  private String location;
+  private LocalDateTime time;
+  private String memo;
+  private Boolean isPublic;
+  private String eventTitle; // 연결된 캘린더이벤트의 제목
+
+}

--- a/src/main/java/emp/emp/treatmentSchedule/entity/TreatmentSchedule.java
+++ b/src/main/java/emp/emp/treatmentSchedule/entity/TreatmentSchedule.java
@@ -1,6 +1,7 @@
 package emp.emp.treatmentSchedule.entity;
 
 import emp.emp.calendar.entity.CalendarEvent;
+import emp.emp.member.entity.Member;
 import emp.emp.treatmentSchedule.dto.request.TreatmentScheduleRequest;
 import emp.emp.util.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/emp/emp/treatmentSchedule/entity/TreatmentSchedule.java
+++ b/src/main/java/emp/emp/treatmentSchedule/entity/TreatmentSchedule.java
@@ -1,0 +1,55 @@
+package emp.emp.treatmentSchedule.entity;
+
+import emp.emp.calendar.entity.CalendarEvent;
+import emp.emp.treatmentSchedule.dto.request.TreatmentScheduleRequest;
+import emp.emp.util.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name="treatment_schedule")
+public class TreatmentSchedule extends BaseEntity {
+
+  @Id
+  @GeneratedValue
+  @Column(name = "treatment_id")
+  private Long treatmentId; // 진료일정 시퀀스ID
+
+  @ManyToOne
+  @JoinColumn(name = "event_id")
+  private CalendarEvent calendarEvent;  // 연결된 캘린더 이벤트
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;  // 회원 정보
+
+  @Column(name = "is_public", nullable = false)
+  private Boolean isPublic = false;  // 진료일정 공개 여부
+
+  @Column(name = "location", nullable = false)
+  private String location;  // 진료 장소
+
+  @Column(name = "time", nullable = false)
+  private LocalDateTime time;  // 진료 시간
+
+  @Column(name = "memo")
+  private String memo;  // 추가 메모
+
+  // 진료일정 업데이트 메소드
+  public void update(TreatmentScheduleRequest request) {
+    this.isPublic = request.getIsPublic();
+    this.location = request.getLocation();
+    this.time = request.getTime();
+    this.memo = request.getMemo();
+  }
+
+
+
+}

--- a/src/main/java/emp/emp/treatmentSchedule/exception/TreatmentErrorCode.java
+++ b/src/main/java/emp/emp/treatmentSchedule/exception/TreatmentErrorCode.java
@@ -1,0 +1,36 @@
+package emp.emp.treatmentSchedule.exception;
+
+import org.springframework.http.HttpStatus;
+
+import emp.emp.util.api_response.error_code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TreatmentErrorCode implements ErrorCode {
+
+  // 공통 오류
+  TREATMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "TRT001", "진료일정을 찾을 수 없습니다."),
+  ACCESS_DENIED(HttpStatus.FORBIDDEN, "TRT002", "이 진료일정에 접근할 권한이 없습니다."),
+  INVALID_TREATMENT_DATA(HttpStatus.BAD_REQUEST, "TRT003", "진료일정 데이터가 유효하지 않습니다."),
+
+  // 캘린더 이벤트 관련 오류
+  CALENDAR_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "TRT004", "연결할 캘린더 이벤트를 찾을 수 없습니다."),
+  EVENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "TRT005", "이 캘린더 이벤트에 접근할 권한이 없습니다."),
+
+  // 필드 유효성 검사 오류
+  INVALID_LOCATION(HttpStatus.BAD_REQUEST, "TRT006", "진료 장소는 필수 입력 항목입니다."),
+  INVALID_TIME_FORMAT(HttpStatus.BAD_REQUEST, "TRT007", "진료 시간 형식이 올바르지 않습니다."),
+  PAST_TIME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "TRT008", "과거 시간으로 진료일정을 등록할 수 없습니다."),
+
+  // 데이터베이스 오류
+  DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "TRT009", "데이터베이스 처리 중 오류가 발생했습니다."),
+
+  // 동시성 오류
+  CONCURRENT_MODIFICATION(HttpStatus.CONFLICT, "TRT010", "다른 사용자가 동시에 이 일정을 수정했습니다. 새로고침 후 다시 시도하세요.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/emp/emp/treatmentSchedule/repository/TreatmentScheduleRepository.java
+++ b/src/main/java/emp/emp/treatmentSchedule/repository/TreatmentScheduleRepository.java
@@ -1,0 +1,14 @@
+package emp.emp.treatmentSchedule.repository;
+
+import emp.emp.member.entity.Member;
+import emp.emp.treatmentSchedule.entity.TreatmentSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TreatmentScheduleRepository extends JpaRepository<TreatmentSchedule, Long> {
+
+
+}

--- a/src/main/java/emp/emp/treatmentSchedule/repository/TreatmentScheduleRepository.java
+++ b/src/main/java/emp/emp/treatmentSchedule/repository/TreatmentScheduleRepository.java
@@ -5,10 +5,55 @@ import emp.emp.treatmentSchedule.entity.TreatmentSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TreatmentScheduleRepository extends JpaRepository<TreatmentSchedule, Long> {
 
+  /**
+   * 특정 회원의 모든 진료일정을 조회하는 메서드
+   * @param member 회원 엔티티
+   * @return 진료일정 목록
+   */
+  List<TreatmentSchedule> findByMember(Member member);
+
+  /**
+   * 특정 일정(z캘린더)ID에 해당하는 진료일정을 조회하는 메서드
+   * @param calendarEventId 캘린더 이벤트 ID
+   * @return 진료일정 (Optional)
+   */
+  Optional<TreatmentSchedule> findByCalendarEvent_EventId(Long calendarEventId);
+
+  /**
+   * 특정 기간 내의 진료일정을 조회하는 메서드
+   * @param start 시작시간
+   * @param end 종료시간
+   * @return 진료일정 목록
+   */
+  List<TreatmentSchedule> findByTimeBetween(LocalDateTime start, LocalDateTime end);
+
+  /**
+   * 특정 회원의 특정 기간 내 진료일정을 조회하는 메서드
+   * @param member 회원Entity
+   * @param start 시작시간
+   * @param end 종료시간
+   * @return 진료일정 목록
+   */
+  List<TreatmentSchedule> findByMemberAndTimeBetween(Member member, LocalDateTime start, LocalDateTime end);
+
+  /**
+   * 공개된 진료일정만 조회하는 메서드
+   * @return 공개된 진료일정 목록
+   */
+  List<TreatmentSchedule> findByIsPublicTrue();
+
+  /**
+   * 특정 위치에서의 진료일정을 조회하는 메서드
+   * @param location 장소
+   * @return 진료일정 목록
+   */
+  List<TreatmentSchedule> findByLocation(String location);
 
 }

--- a/src/main/java/emp/emp/treatmentSchedule/service/TreatmentScheduleService.java
+++ b/src/main/java/emp/emp/treatmentSchedule/service/TreatmentScheduleService.java
@@ -1,0 +1,18 @@
+package emp.emp.treatmentSchedule.service;
+
+import emp.emp.auth.custom.CustomUserDetails;
+import emp.emp.treatmentSchedule.dto.request.TreatmentScheduleRequest;
+import emp.emp.treatmentSchedule.dto.response.TreatmentScheduleResponse;
+
+public interface TreatmentScheduleService {
+
+  /**
+   * 진료일정 등록
+   * @param userDetails 사용자의정보
+   * @param request 등록요청DTO
+   * @return 응답DTO
+   */
+  TreatmentScheduleResponse createTreatmentSchedule(CustomUserDetails userDetails, TreatmentScheduleRequest request);
+
+
+}

--- a/src/main/java/emp/emp/treatmentSchedule/service/TreatmentScheduleService.java
+++ b/src/main/java/emp/emp/treatmentSchedule/service/TreatmentScheduleService.java
@@ -8,11 +8,26 @@ public interface TreatmentScheduleService {
 
   /**
    * 진료일정 등록
-   * @param userDetails 사용자의정보
+   * @param userDetails 사용자의 정보
    * @param request 등록요청DTO
    * @return 응답DTO
    */
   TreatmentScheduleResponse createTreatmentSchedule(CustomUserDetails userDetails, TreatmentScheduleRequest request);
 
+  /**
+   * 진료일정 수정
+   * @param userDetails
+   * @param treatmentId
+   * @param request
+   * @return
+   */
+  TreatmentScheduleResponse updateTreatmentSchedule(CustomUserDetails userDetails, Long treatmentId, TreatmentScheduleRequest request);
+
+  /**
+   * 진료일정 삭제
+   * @param userDetails
+   * @param treatmentId
+   */
+  void deleteTreatmentSchedule(CustomUserDetails userDetails, Long treatmentId);
 
 }

--- a/src/main/java/emp/emp/treatmentSchedule/service/TreatmentScheduleServiceImpl.java
+++ b/src/main/java/emp/emp/treatmentSchedule/service/TreatmentScheduleServiceImpl.java
@@ -3,60 +3,200 @@ package emp.emp.treatmentSchedule.service;
 import emp.emp.auth.custom.CustomUserDetails;
 import emp.emp.calendar.entity.CalendarEvent;
 import emp.emp.calendar.repository.CalendarRepository;
+import emp.emp.exception.BusinessException;
 import emp.emp.member.entity.Member;
 import emp.emp.treatmentSchedule.dto.request.TreatmentScheduleRequest;
 import emp.emp.treatmentSchedule.dto.response.TreatmentScheduleResponse;
 import emp.emp.treatmentSchedule.entity.TreatmentSchedule;
+import emp.emp.treatmentSchedule.exception.TreatmentErrorCode;
 import emp.emp.treatmentSchedule.repository.TreatmentScheduleRepository;
 import emp.emp.util.security.SecurityUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TreatmentScheduleServiceImpl implements TreatmentScheduleService {
 
-  private final SecurityUtil securityUtil;
-  private final CalendarRepository calendarRepository;
   private final TreatmentScheduleRepository treatmentScheduleRepository;
+  private final CalendarRepository calendarRepository;
+  private final SecurityUtil securityUtil;
 
   @Override
   @Transactional
-  public TreatmentScheduleResponse createTreatmentSchedule(CustomUserDetails userDetails, TreatmentScheduleRequest request){
+  public TreatmentScheduleResponse createTreatmentSchedule(CustomUserDetails userDetails, TreatmentScheduleRequest request) {
+    try {
+      // 유효성 검사
+      validateRequest(request);
 
-    // 현재 로그인한 사용자의 정보 가져오기
-    Member currentMember = securityUtil.getCurrentMember();
+      // 현재 로그인한 사용자 정보 가져오기
+      Member currentMember = securityUtil.getCurrentMember();
 
-    // 연결한 캘린더이벤트 찾기
-    CalendarEvent calendarEvent = calendarRepository.findById(request.getEventId())
-            .orElseThrow(() -> new RuntimeException("캘린더이벤트를 찾을수 없슈"));
+      // 연결할 캘린더 이벤트 찾기
+      CalendarEvent calendarEvent = calendarRepository.findById(request.getEventId())
+              .orElseThrow(() -> new BusinessException(TreatmentErrorCode.CALENDAR_EVENT_NOT_FOUND));
 
-    // 캘린더이벤트 소유자 확인
-    if(!calendarEvent.getMember().equals(currentMember)){
-      throw new RuntimeException("접근권한 없슈");
+      // 캘린더이벤트 소유자 확인
+      if (!calendarEvent.getMember().equals(currentMember)) {
+        throw new BusinessException(TreatmentErrorCode.EVENT_ACCESS_DENIED);
+      }
+
+      // 진료일정 생성
+      TreatmentSchedule treatmentSchedule = TreatmentSchedule.builder()
+              .calendarEvent(calendarEvent)
+              .member(currentMember)
+              .isPublic(request.getIsPublic())
+              .location(request.getLocation())
+              .time(request.getTime())
+              .memo(request.getMemo())
+              .build();
+
+      treatmentScheduleRepository.save(treatmentSchedule);
+
+      return toResponse(treatmentSchedule);
+    } catch (DataIntegrityViolationException e) {
+      log.error("데이터 무결성 위반 오류 : {}", e.getMessage());
+      throw new BusinessException(TreatmentErrorCode.DATABASE_ERROR);
+    } catch (DataAccessException e) {
+      log.error("데이터 접근 오류 : {}", e.getMessage());
+      throw new BusinessException(TreatmentErrorCode.DATABASE_ERROR);
+    } catch (BusinessException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("진료일정 생성 중 예상치 못한 오류 발생!! : {}", e.getMessage(), e);
+      throw new BusinessException(TreatmentErrorCode.INVALID_TREATMENT_DATA);
     }
+  }
 
-    // 진료일정 생성
-    TreatmentSchedule treatmentSchedule = TreatmentSchedule.builder()
-            .calendarEvent(calendarEvent)
-            .member(currentMember)
-            .isPublic(request.getIsPublic())
-            .location(request.getLocation())
-            .time(request.getTime())
-            .memo(request.getMemo())
-            .build();
+  @Override
+  @Transactional
+  public TreatmentScheduleResponse updateTreatmentSchedule(CustomUserDetails userDetails, Long treatmentId, TreatmentScheduleRequest request) {
+    try {
 
-    treatmentScheduleRepository.save(treatmentSchedule);
+      validateRequest(request);
 
-    return toResponse(treatmentSchedule);
+      Member currentMember = securityUtil.getCurrentMember();
+
+      // 진료일정 찾기 & 권한 확인
+      TreatmentSchedule treatmentSchedule = findByIdAndValidate(treatmentId, currentMember);
+
+      // 캘린더 이벤트가 변경된 경우 -> 새 이벤트 확인
+      if (!treatmentSchedule.getCalendarEvent().getEventId().equals(request.getEventId())) {
+        CalendarEvent newCalendarEvent = calendarRepository.findById(request.getEventId())
+                .orElseThrow(() -> new BusinessException(TreatmentErrorCode.CALENDAR_EVENT_NOT_FOUND));
+
+        // 새 이벤트의 소유자 확인
+        if (!newCalendarEvent.getMember().equals(currentMember)) {
+          throw new BusinessException(TreatmentErrorCode.EVENT_ACCESS_DENIED);
+        }
+
+        treatmentSchedule.setCalendarEvent(newCalendarEvent);
+      }
+
+      treatmentSchedule.update(request);
+
+      return toResponse(treatmentSchedule);
+    } catch (DataIntegrityViolationException e) {
+      log.error("데이터 무결성 위반 오류 : {}", e.getMessage());
+      throw new BusinessException(TreatmentErrorCode.DATABASE_ERROR);
+    } catch (DataAccessException e) {
+      log.error("데이터 접근 오류 : {}", e.getMessage());
+      throw new BusinessException(TreatmentErrorCode.DATABASE_ERROR);
+    } catch (BusinessException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("진료일정 수정 중 예상치 못한 오류 발생!! : {}", e.getMessage(), e);
+      throw new BusinessException(TreatmentErrorCode.INVALID_TREATMENT_DATA);
+    }
+  }
+
+  @Override
+  @Transactional
+  public void deleteTreatmentSchedule(CustomUserDetails userDetails, Long treatmentId) {
+    try {
+
+      Member currentMember = securityUtil.getCurrentMember();
+
+      TreatmentSchedule treatmentSchedule = findByIdAndValidate(treatmentId, currentMember);
+
+      treatmentScheduleRepository.delete(treatmentSchedule);
+    } catch (DataAccessException e) {
+      log.error("데이터 접근 오류 : {}", e.getMessage());
+      throw new BusinessException(TreatmentErrorCode.DATABASE_ERROR);
+    } catch (BusinessException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("진료일정 삭제 중 예상치 못한 오류 발생!! : {}", e.getMessage(), e);
+      throw new BusinessException(TreatmentErrorCode.INVALID_TREATMENT_DATA);
+    }
   }
 
 
+  /**
+   * 요청 데이터 유효성 검사
+   * @param request 진료일정 요청 DTO
+   * @throws BusinessException 유효성 검사 실패 시
+   */
+  private void validateRequest(TreatmentScheduleRequest request) {
+    // eventId 검사
+    if (request.getEventId() == null) {
+      throw new BusinessException(TreatmentErrorCode.CALENDAR_EVENT_NOT_FOUND);
+    }
 
+    // 위치 검사
+    if (request.getLocation() == null || request.getLocation().trim().isEmpty()) {
+      throw new BusinessException(TreatmentErrorCode.INVALID_LOCATION);
+    }
+
+    // 시간 검사
+    if (request.getTime() == null) {
+      throw new BusinessException(TreatmentErrorCode.INVALID_TIME_FORMAT);
+    }
+
+    // 과거 시간 검사 (선택적)
+    // if (request.getTime().isBefore(LocalDateTime.now())) {
+    //     throw new BusinessException(TreatmentErrorCode.PAST_TIME_NOT_ALLOWED);
+    // }
+
+    // isPublic이 null인 경우 기본값 설정
+    if (request.getIsPublic() == null) {
+      request.setIsPublic(false);
+    }
+  }
 
   /**
-   * 진료일정 엔티티를 응답DTO로 변환
+   * 진료일정 ID로 조회 및 사용자 권한 검증
+   * @param treatmentId 진료일정 ID
+   * @param currentMember 현재 사용자
+   * @return 진료일정 엔티티
+   * @throws BusinessException 진료일정을 찾을 수 없거나 접근 권한이 없는 경우
+   */
+  private TreatmentSchedule findByIdAndValidate(Long treatmentId, Member currentMember) {
+    // treatmentId 유효성 검사
+    if (treatmentId == null) {
+      throw new BusinessException(TreatmentErrorCode.TREATMENT_NOT_FOUND);
+    }
+
+    // 진료일정 찾기
+    TreatmentSchedule treatmentSchedule = treatmentScheduleRepository.findById(treatmentId)
+            .orElseThrow(() -> new BusinessException(TreatmentErrorCode.TREATMENT_NOT_FOUND));
+
+    // 소유자 검증
+    if (!treatmentSchedule.getMember().equals(currentMember)) {
+      throw new BusinessException(TreatmentErrorCode.ACCESS_DENIED);
+    }
+
+    return treatmentSchedule;
+  }
+
+  /**
+   * 진료일정 엔티티를 응답 DTO로 변환
    * @param treatmentSchedule 진료일정 엔티티
    * @return 진료일정 응답 DTO
    */

--- a/src/main/java/emp/emp/treatmentSchedule/service/TreatmentScheduleServiceImpl.java
+++ b/src/main/java/emp/emp/treatmentSchedule/service/TreatmentScheduleServiceImpl.java
@@ -1,0 +1,75 @@
+package emp.emp.treatmentSchedule.service;
+
+import emp.emp.auth.custom.CustomUserDetails;
+import emp.emp.calendar.entity.CalendarEvent;
+import emp.emp.calendar.repository.CalendarRepository;
+import emp.emp.member.entity.Member;
+import emp.emp.treatmentSchedule.dto.request.TreatmentScheduleRequest;
+import emp.emp.treatmentSchedule.dto.response.TreatmentScheduleResponse;
+import emp.emp.treatmentSchedule.entity.TreatmentSchedule;
+import emp.emp.treatmentSchedule.repository.TreatmentScheduleRepository;
+import emp.emp.util.security.SecurityUtil;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TreatmentScheduleServiceImpl implements TreatmentScheduleService {
+
+  private final SecurityUtil securityUtil;
+  private final CalendarRepository calendarRepository;
+  private final TreatmentScheduleRepository treatmentScheduleRepository;
+
+  @Override
+  @Transactional
+  public TreatmentScheduleResponse createTreatmentSchedule(CustomUserDetails userDetails, TreatmentScheduleRequest request){
+
+    // 현재 로그인한 사용자의 정보 가져오기
+    Member currentMember = securityUtil.getCurrentMember();
+
+    // 연결한 캘린더이벤트 찾기
+    CalendarEvent calendarEvent = calendarRepository.findById(request.getEventId())
+            .orElseThrow(() -> new RuntimeException("캘린더이벤트를 찾을수 없슈"));
+
+    // 캘린더이벤트 소유자 확인
+    if(!calendarEvent.getMember().equals(currentMember)){
+      throw new RuntimeException("접근권한 없슈");
+    }
+
+    // 진료일정 생성
+    TreatmentSchedule treatmentSchedule = TreatmentSchedule.builder()
+            .calendarEvent(calendarEvent)
+            .member(currentMember)
+            .isPublic(request.getIsPublic())
+            .location(request.getLocation())
+            .time(request.getTime())
+            .memo(request.getMemo())
+            .build();
+
+    treatmentScheduleRepository.save(treatmentSchedule);
+
+    return toResponse(treatmentSchedule);
+  }
+
+
+
+
+  /**
+   * 진료일정 엔티티를 응답DTO로 변환
+   * @param treatmentSchedule 진료일정 엔티티
+   * @return 진료일정 응답 DTO
+   */
+  private TreatmentScheduleResponse toResponse(TreatmentSchedule treatmentSchedule) {
+    return TreatmentScheduleResponse.builder()
+            .treatmentId(treatmentSchedule.getTreatmentId())
+            .eventId(treatmentSchedule.getCalendarEvent().getEventId())
+            .verifyId(treatmentSchedule.getMember().getVerifyId())
+            .isPublic(treatmentSchedule.getIsPublic())
+            .location(treatmentSchedule.getLocation())
+            .time(treatmentSchedule.getTime())
+            .memo(treatmentSchedule.getMemo())
+            .eventTitle(treatmentSchedule.getCalendarEvent().getTitle())
+            .build();
+  }
+}


### PR DESCRIPTION
작성자: 정승원
작성일: 2025-05-11 11시26분

### 진료일정 기능 구현
작성자: 정승원
작성일: 2025-05-11 11시26분

### 진료일정 기능 구현
- TreatmentScheduleController, TreatmentScheduleService, TreatmentScheduleServiceImpl 등 주요 클래스에서 진료일정 등록/수정/삭제 API를 구현했습니다.
- 진료일정 등록 시 유효성 검사를 하며 캘린더 이벤트 소유자인지 확인하는 로직을 넣었습니다.
- 진료일정 수정 시  권한 검증 구현했습니다.
- 진료일정 삭제 시 사용자 권한 검증 구현했습니다.
- 승환님 피드백에 따라 관련 오류코드(TreatmentErrorCode) 정의 하였습니다.

참고로 브랜치를 main으로 빠진후 브랜치를 생성했어야 하나그러지 못하고 바로 캘린더이벤트 분기에서 브랜치를 생성하게 된 점 죄송합니다.