### PR TITLE
fix/진료일정 캘린더와 양방향으로 수정

### DIFF
--- a/src/main/java/emp/emp/calendar/entity/CalendarEvent.java
+++ b/src/main/java/emp/emp/calendar/entity/CalendarEvent.java
@@ -5,6 +5,7 @@ import emp.emp.calendar.enums.CalendarEventType;
 import emp.emp.medical.entity.MedicalResult;
 import emp.emp.medication.entity.MedicationManagement;
 import emp.emp.member.entity.Member;
+import emp.emp.treatmentSchedule.entity.TreatmentSchedule;
 import emp.emp.util.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -38,6 +39,9 @@ public class CalendarEvent extends BaseEntity {
   private LocalDateTime endDate;
 
   private Integer priority;
+
+  @OneToOne(mappedBy = "calendarEvent", cascade = CascadeType.ALL, orphanRemoval = true)
+  private TreatmentSchedule treatmentSchedule;
 
   // 진료결과와 일대일 관계
   @OneToOne(mappedBy = "calendarEvent", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/emp/emp/config/RedisConfig.java
+++ b/src/main/java/emp/emp/config/RedisConfig.java
@@ -16,8 +16,8 @@ public class RedisConfig {
 	@Value("${spring.data.redis.port}")
 	private int port;
 
-//	@Value("${spring.data.redis.password}")
-//		private String password;
+	@Value("${spring.data.redis.password}")
+		private String password;
 
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {

--- a/src/main/java/emp/emp/config/RedisConfig.java
+++ b/src/main/java/emp/emp/config/RedisConfig.java
@@ -25,7 +25,7 @@ public class RedisConfig {
 
 		configuration.setHostName(host);
 		configuration.setPort(port);
-		// configuration.setPassword(password);
+		configuration.setPassword(password);
 
 		return new LettuceConnectionFactory(configuration);
 	}

--- a/src/main/java/emp/emp/config/RedisConfig.java
+++ b/src/main/java/emp/emp/config/RedisConfig.java
@@ -16,8 +16,8 @@ public class RedisConfig {
 	@Value("${spring.data.redis.port}")
 	private int port;
 
-	@Value("${spring.data.redis.password}")
-		private String password;
+//	@Value("${spring.data.redis.password}")
+//		private String password;
 
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
@@ -25,7 +25,7 @@ public class RedisConfig {
 
 		configuration.setHostName(host);
 		configuration.setPort(port);
-		configuration.setPassword(password);
+		// configuration.setPassword(password);
 
 		return new LettuceConnectionFactory(configuration);
 	}

--- a/src/main/java/emp/emp/config/SecurityConfig.java
+++ b/src/main/java/emp/emp/config/SecurityConfig.java
@@ -32,13 +32,13 @@ import lombok.RequiredArgsConstructor;
 public class SecurityConfig {
 
 	private static final List<String> CORS_WHITELIST = List.of(
-		"http://localhost:5173"
+					"http://localhost:5173"
 	);
 	private static final List<String> WHITELIST = List.of(
-		"/login",
-		"/api/register",
-		"/api/login",
-		"/api/token/**"
+					"/login",
+					"/api/register",
+					"/api/login",
+					"/api/token/**"
 //		"/api/emergency/**"
 	);
 
@@ -51,35 +51,35 @@ public class SecurityConfig {
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
 		http
-			.csrf(AbstractHttpConfigurer::disable)
-			.formLogin(AbstractHttpConfigurer::disable)
-			.httpBasic(AbstractHttpConfigurer::disable);
+						.csrf(AbstractHttpConfigurer::disable)
+						.formLogin(AbstractHttpConfigurer::disable)
+						.httpBasic(AbstractHttpConfigurer::disable);
 
 		http
-			.oauth2Login(oauth2 -> oauth2
-				.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
-					.userService(customOAuth2UserService))
-				.successHandler(oAuth2SuccessHandler)
-				.failureHandler(oAuth2FailureHandler)
-			);
+						.oauth2Login(oauth2 -> oauth2
+										.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
+														.userService(customOAuth2UserService))
+										.successHandler(oAuth2SuccessHandler)
+										.failureHandler(oAuth2FailureHandler)
+						);
 
 		http
-			.authorizeHttpRequests(auth -> auth
-				.requestMatchers(WHITELIST.toArray(new String[0])).permitAll()
-				.requestMatchers("/api/auth/semi/**").hasRole("SEMI_USER")
-				.requestMatchers("/api/auth/user/**").hasRole("USER")
-				.anyRequest().authenticated()
-			);
+						.authorizeHttpRequests(auth -> auth
+										.requestMatchers(WHITELIST.toArray(new String[0])).permitAll()
+										.requestMatchers("/api/auth/semi/**").hasRole("SEMI_USER")
+										.requestMatchers("/api/auth/user/**").hasRole("USER")
+										.anyRequest().authenticated()
+						);
 
 		http
-			.addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+						.addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 
 		http
-			.sessionManagement((session) -> session
-				.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
+						.sessionManagement((session) -> session
+										.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
 
 		http
-			.cors(corsCustomizer -> corsCustomizer.configurationSource(corsConfigurationSource()));
+						.cors(corsCustomizer -> corsCustomizer.configurationSource(corsConfigurationSource()));
 
 		return http.build();
 	}

--- a/src/main/java/emp/emp/treatmentSchedule/entity/TreatmentSchedule.java
+++ b/src/main/java/emp/emp/treatmentSchedule/entity/TreatmentSchedule.java
@@ -23,7 +23,7 @@ public class TreatmentSchedule extends BaseEntity {
   @Column(name = "treatment_id")
   private Long treatmentId; // 진료일정 시퀀스ID
 
-  @ManyToOne
+  @OneToOne
   @JoinColumn(name = "event_id")
   private CalendarEvent calendarEvent;  // 연결된 캘린더 이벤트
 


### PR DESCRIPTION
작성자 : 정승원
작성일 : 2025-06-06
내용 :
- 모든 건강정보를 event_id로 캘린더와 일대일 연결을 하기위해  TreatmentSchedule과 CalendarEvent 관계를 단방향 다대일에서 양방향 일대일로 수정하였습니다.
- 따라서 진료일정, 진료결과, 복약관리의 모든 건강 정보가 캘린더 연결 구조의 일관성을 보장하게 수정하였습니다.

확인부탁드립니다.

다들 마지막까지 화이팅 합시다~~~~~~~~~
